### PR TITLE
Remove namespace being specified via package attribute in android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="nl.u2312.app_set_id">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Plugin fails to compile with gradle > 8.0.0. This should fix it

```
Incorrect package="nl.u2312.app_set_id" found in source AndroidManifest.xml: /Users/adityagupta/.pub-cache/hosted/pub.dev/app_set_id-1.2.0/android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
Recommendation: remove package="nl.u2312.app_set_id" from the source AndroidManifest.xml: /Users/adityagupta/.pub-cache/hosted/pub.dev/app_set_id-1.2.0/android/src/main/AndroidManifest.xml.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app_set_id:processReleaseManifest'.
> A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
   > Incorrect package="nl.u2312.app_set_id" found in source AndroidManifest.xml: /Users/adityagupta/.pub-cache/hosted/pub.dev/app_set_id-1.2.0/android/src/main/AndroidManifest.xml.
     Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
     Recommendation: remove package="nl.u2312.app_set_id" from the source AndroidManifest.xml: /Users/adityagupta/.pub-cache/hosted/pub.dev/app_set_id-1.2.0/android/src/main/AndroidManifest.xml.

```